### PR TITLE
Fix script dependency

### DIFF
--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -206,7 +206,7 @@ add_action('wp_enqueue_scripts', function () {
     wp_enqueue_script(
         'seedling-product-limit',
         plugin_dir_url(__FILE__) . 'assets/js/seedling-product-limit.js',
-        [],
+        ['jquery'], // Подключаем jQuery, используемую WordPress
         null,
         true
     );


### PR DESCRIPTION
## Summary
- ensure seedling-product-limit.js depends on WordPress's jQuery

## Testing
- `php -l woo-seedling-limiter.php`


------
https://chatgpt.com/codex/tasks/task_e_68717fff8ff8832da3abf73743824a0d