### PR TITLE
Refactor plugin logic into a class with docs

### DIFF
--- a/assets/js/seedling-cart-validation.js
+++ b/assets/js/seedling-cart-validation.js
@@ -1,10 +1,15 @@
+// Скрипт проверяет корзину на соответствие минимальным ограничениям.
 document.addEventListener('DOMContentLoaded', function () {
-    // Настройки для AJAX-запросов передаются из PHP
+    // URL-адрес для проверки корзины через AJAX
     const ajaxUrl = seedlingCartSettings.ajaxUrl;
+    // URL-адрес для получения общего количества по категории
     const totalUrl = seedlingCartSettings.totalCheckUrl;
+    // Кнопки оформления заказа, которые нужно блокировать при ошибках
     const selectors = ['.checkout-button', '#place_order', 'a.checkout'];
+    // ID контейнера для вывода сообщений об ошибках
     const noticeId = 'seedling-dynamic-warning';
 
+    // Отображает список сообщений об ошибках в специальном блоке
     function showMessages(msgs) {
 		let box = document.getElementById(noticeId);
 		if (!box) {
@@ -32,6 +37,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	}
 
 
+    // Активирует или блокирует кнопки оформления заказа
     function disableBtns(disable) {
 		selectors.forEach(sel => {
 			document.querySelectorAll(sel).forEach(btn => {
@@ -52,7 +58,8 @@ document.addEventListener('DOMContentLoaded', function () {
 		});
 	}
 
-	function preventIfDisabled(e) {
+        // Предотвращает действие по клику, если элемент заблокирован
+        function preventIfDisabled(e) {
 		const el = e.currentTarget;
 		if (el.classList.contains('disabled') || el.getAttribute('aria-disabled') === 'true') {
 			e.preventDefault();
@@ -60,6 +67,7 @@ document.addEventListener('DOMContentLoaded', function () {
 		}
 	}
 
+    // Проверяет корзину через AJAX и отображает найденные ошибки
     function checkCart() {
         fetch(ajaxUrl, { credentials: 'same-origin' })
             .then(r => r.json())
@@ -87,9 +95,11 @@ document.addEventListener('DOMContentLoaded', function () {
             });
     }
 
+    // Проверяем корзину сразу и при любых изменениях DOM
     checkCart();
     const mo = new MutationObserver(checkCart);
     mo.observe(document.body, { childList: true, subtree: true });
-	
-	jQuery(document.body).on('wc_fragments_refreshed updated_wc_div', checkCart);
+
+    // Проверяем корзину после обновления фрагментов WooCommerce
+    jQuery(document.body).on('wc_fragments_refreshed updated_wc_div', checkCart);
 });

--- a/assets/js/seedling-product-limit.js
+++ b/assets/js/seedling-product-limit.js
@@ -1,10 +1,16 @@
+// Скрипт обеспечивает выполнение минимального количества для вариаций товара
+// на странице продукта.
 document.addEventListener('DOMContentLoaded', function () {
-    // Получаем настройки, переданные из PHP
+    // Минимальное количество для текущей вариации
     const min = seedlingProductSettings.minQty;
+    // Слаг категории, для которой действует ограничение
     const slug = seedlingProductSettings.slug;
     const body = document.body;
+    // Основная форма выбора вариаций
     const variationForm = document.querySelector('form.variations_form');
+    // Поле ввода количества товара
     const qtyInput = document.querySelector('input.qty');
+    // Скрытое поле с выбранной вариацией
     const variationIdInput = document.querySelector('input[name="variation_id"]');
 
     // Проверяем, существует ли форма выбора вариации. Если её нет,
@@ -17,11 +23,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
     if (!qtyInput || !variationIdInput) return;
 
-    // Минимальное значение, которое допускается в поле количества.
-    // Обновляется функцией checkAndUpdateQuantity.
+    // Фактический минимум, разрешённый в поле количества.
+    // Значение изменяется функцией checkAndUpdateQuantity.
     let enforcedMin = 1;
 
-    // Хранит кнопку уменьшения, чтобы можно было снять обработчик при её замене.
+    // Ссылка на кнопку "минус" для корректного управления обработчиками
     let boundMinusBtn = null;
 
     /**

--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -6,245 +6,336 @@
  * Author: Дмитрий Анисимов
  */
 
-if (!defined('ABSPATH')) exit;
-
-// === Настройки в админке ===
-add_action('admin_menu', function () {
-    add_submenu_page(
-        'woocommerce',
-        'Ограничения товаров',
-        'Ограничения товаров',
-        'manage_woocommerce',
-        'woo-seedling-limit',
-        'render_seedling_limit_settings_page'
-    );
-});
-
-function render_seedling_limit_settings_page() {
-    ?>
-    <div class="wrap">
-        <h1>Ограничения категории</h1>
-        <form method="post" action="options.php">
-            <?php
-            settings_fields('woo_seedling_limit_settings');
-            do_settings_sections('woo-seedling-limit');
-            submit_button();
-            ?>
-        </form>
-    </div>
-    <?php
+if (!defined('ABSPATH')) {
+    exit;
 }
 
-add_action('admin_init', function () {
-    register_setting('woo_seedling_limit_settings', 'woo_seedling_category_slug');
-    register_setting('woo_seedling_limit_settings', 'woo_seedling_min_variation');
-    register_setting('woo_seedling_limit_settings', 'woo_seedling_min_total');
-    register_setting('woo_seedling_limit_settings', 'woo_seedling_msg_variation');
-    register_setting('woo_seedling_limit_settings', 'woo_seedling_msg_total');
+/**
+ * Main plugin class responsible for registering hooks and handling validation.
+ */
+class Seedling_Limiter
+{
+    /**
+     * Seedling_Limiter constructor.
+     *
+     * Registers all WordPress hooks required for the plugin to operate.
+     */
+    public function __construct()
+    {
+        add_action('admin_menu', [$this, 'add_admin_menu']);
+        add_action('admin_init', [$this, 'register_settings']);
 
-    add_settings_section('woo_seedling_main', 'Основные настройки', null, 'woo-seedling-limit');
+        add_filter(
+            'woocommerce_add_to_cart_validation',
+            [$this, 'validate_add_to_cart'],
+            10,
+            5
+        );
 
-    add_settings_field('woo_seedling_category_slug', 'Слаг категории', function () {
-        $value = get_option('woo_seedling_category_slug', 'seedling');
-        echo "<input type='text' name='woo_seedling_category_slug' value='" . esc_attr($value) . "' />";
-    }, 'woo-seedling-limit', 'woo_seedling_main');
+        add_action('woocommerce_checkout_process', [$this, 'validate_cart']);
+        add_action('wp_ajax_seedling_validate_cart_full', [$this, 'validate_cart']);
+        add_action('wp_ajax_nopriv_seedling_validate_cart_full', [$this, 'validate_cart']);
 
-    add_settings_field('woo_seedling_min_variation', 'Минимум на вариацию', function () {
-        $value = get_option('woo_seedling_min_variation', 5);
-        echo "<input type='number' name='woo_seedling_min_variation' value='" . esc_attr($value) . "' min='1' />";
-    }, 'woo-seedling-limit', 'woo_seedling_main');
+        add_action('wp_ajax_seedling_get_cart_qty', [$this, 'get_cart_qty']);
+        add_action('wp_ajax_nopriv_seedling_get_cart_qty', [$this, 'get_cart_qty']);
 
-    add_settings_field('woo_seedling_min_total', 'Общий минимум по категории', function () {
-        $value = get_option('woo_seedling_min_total', 20);
-        echo "<input type='number' name='woo_seedling_min_total' value='" . esc_attr($value) . "' min='1' />";
-    }, 'woo-seedling-limit', 'woo_seedling_main');
+        add_action('wp_ajax_seedling_get_cat_total', [$this, 'get_cat_total']);
+        add_action('wp_ajax_nopriv_seedling_get_cat_total', [$this, 'get_cat_total']);
 
-    add_settings_field('woo_seedling_msg_variation', 'Сообщение (для вариации < минимума)', function () {
-        $value = get_option('woo_seedling_msg_variation', 'Минимальное количество для этой вариации — {min} шт. Сейчас — {current}.');
-        echo "<input type='text' name='woo_seedling_msg_variation' value='" . esc_attr($value) . "' style='width: 100%' />";
-    }, 'woo-seedling-limit', 'woo_seedling_main');
+        add_action('wp_enqueue_scripts', [$this, 'enqueue_product_script']);
+        add_action('wp_enqueue_scripts', [$this, 'enqueue_cart_script']);
+    }
 
-    add_settings_field('woo_seedling_msg_total', 'Сообщение (общее < минимума)', function () {
-        $value = get_option('woo_seedling_msg_total', 'Общее количество товаров из категории должно быть не менее {min}. Сейчас — {current}.');
-        echo "<input type='text' name='woo_seedling_msg_total' value='" . esc_attr($value) . "' style='width: 100%' />";
-    }, 'woo-seedling-limit', 'woo_seedling_main');
-});
+    /**
+     * Adds plugin submenu under WooCommerce menu.
+     */
+    public function add_admin_menu(): void
+    {
+        add_submenu_page(
+            'woocommerce',
+            'Ограничения товаров',
+            'Ограничения товаров',
+            'manage_woocommerce',
+            'woo-seedling-limit',
+            [$this, 'render_settings_page']
+        );
+    }
 
-// === Серверная проверка ===
-add_filter('woocommerce_add_to_cart_validation', function ($passed, $product_id, $quantity, $variation_id = null) {
-    $slug = get_option('woo_seedling_category_slug', 'seedling');
-    $min_qty = (int)get_option('woo_seedling_min_variation', 5);
-    if (!$variation_id) return $passed;
-    if (!has_term($slug, 'product_cat', $product_id)) return $passed;
+    /**
+     * Renders the settings page for plugin options.
+     */
+    public function render_settings_page(): void
+    {
+        ?>
+        <div class="wrap">
+            <h1>Ограничения категории</h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields('woo_seedling_limit_settings');
+                do_settings_sections('woo-seedling-limit');
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
 
-    $current_qty = 0;
-    foreach (WC()->cart->get_cart() as $item) {
-        if ($item['variation_id'] == $variation_id) {
-            $current_qty += $item['quantity'];
+    /**
+     * Registers all plugin settings displayed on the admin page.
+     */
+    public function register_settings(): void
+    {
+        register_setting('woo_seedling_limit_settings', 'woo_seedling_category_slug');
+        register_setting('woo_seedling_limit_settings', 'woo_seedling_min_variation');
+        register_setting('woo_seedling_limit_settings', 'woo_seedling_min_total');
+        register_setting('woo_seedling_limit_settings', 'woo_seedling_msg_variation');
+        register_setting('woo_seedling_limit_settings', 'woo_seedling_msg_total');
+
+        add_settings_section('woo_seedling_main', 'Основные настройки', null, 'woo-seedling-limit');
+
+        add_settings_field(
+            'woo_seedling_category_slug',
+            'Слаг категории',
+            function () {
+                $value = get_option('woo_seedling_category_slug', 'seedling');
+                echo "<input type='text' name='woo_seedling_category_slug' value='" . esc_attr($value) . "' />";
+            },
+            'woo-seedling-limit',
+            'woo_seedling_main'
+        );
+
+        add_settings_field(
+            'woo_seedling_min_variation',
+            'Минимум на вариацию',
+            function () {
+                $value = get_option('woo_seedling_min_variation', 5);
+                echo "<input type='number' name='woo_seedling_min_variation' value='" . esc_attr($value) . "' min='1' />";
+            },
+            'woo-seedling-limit',
+            'woo_seedling_main'
+        );
+
+        add_settings_field(
+            'woo_seedling_min_total',
+            'Общий минимум по категории',
+            function () {
+                $value = get_option('woo_seedling_min_total', 20);
+                echo "<input type='number' name='woo_seedling_min_total' value='" . esc_attr($value) . "' min='1' />";
+            },
+            'woo-seedling-limit',
+            'woo_seedling_main'
+        );
+
+        add_settings_field(
+            'woo_seedling_msg_variation',
+            'Сообщение (для вариации < минимума)',
+            function () {
+                $value = get_option(
+                    'woo_seedling_msg_variation',
+                    'Минимальное количество для этой вариации — {min} шт. Сейчас — {current}.'
+                );
+                echo "<input type='text' name='woo_seedling_msg_variation' value='" . esc_attr($value) . "' style='width: 100%' />";
+            },
+            'woo-seedling-limit',
+            'woo_seedling_main'
+        );
+
+        add_settings_field(
+            'woo_seedling_msg_total',
+            'Сообщение (общее < минимума)',
+            function () {
+                $value = get_option(
+                    'woo_seedling_msg_total',
+                    'Общее количество товаров из категории должно быть не менее {min}. Сейчас — {current}.'
+                );
+                echo "<input type='text' name='woo_seedling_msg_total' value='" . esc_attr($value) . "' style='width: 100%' />";
+            },
+            'woo-seedling-limit',
+            'woo_seedling_main'
+        );
+    }
+
+    /**
+     * Validates adding a product variation to the cart.
+     *
+     * @param bool     $passed       Whether the add to cart should proceed.
+     * @param int      $product_id   ID of the product being added.
+     * @param int      $quantity     Quantity requested by the customer.
+     * @param int|null $variation_id ID of the variation being added.
+     *
+     * @return bool Whether the add to cart action is allowed.
+     */
+    public function validate_add_to_cart($passed, $product_id, $quantity, $variation_id = null)
+    {
+        $slug    = get_option('woo_seedling_category_slug', 'seedling');
+        $min_qty = (int) get_option('woo_seedling_min_variation', 5);
+        if (!$variation_id) {
+            return $passed;
+        }
+        if (!has_term($slug, 'product_cat', $product_id)) {
+            return $passed;
+        }
+
+        $current_qty = 0;
+        foreach (WC()->cart->get_cart() as $item) {
+            if ($item['variation_id'] == $variation_id) {
+                $current_qty += $item['quantity'];
+            }
+        }
+
+        if (($current_qty + $quantity) < $min_qty) {
+            wc_add_notice("Минимальное количество для этой вариации — {$min_qty} шт.", 'error');
+            return false;
+        }
+
+        return $passed;
+    }
+
+    /**
+     * Validates the cart either during checkout or via AJAX call.
+     */
+    public function validate_cart(): void
+    {
+        $slug      = get_option('woo_seedling_category_slug', 'seedling');
+        $min_qty   = (int) get_option('woo_seedling_min_variation', 5);
+        $min_total = (int) get_option('woo_seedling_min_total', 20);
+        $msg_var   = get_option('woo_seedling_msg_variation');
+        $msg_total = get_option('woo_seedling_msg_total');
+
+        $variation_quantities = [];
+        $total_in_category    = 0;
+        $errors               = [];
+
+        foreach (WC()->cart->get_cart() as $item) {
+            $variation_id = $item['variation_id'];
+            $parent_id    = $item['product_id'];
+            if (!$variation_id || !has_term($slug, 'product_cat', $parent_id)) {
+                continue;
+            }
+
+            $variation_quantities[$variation_id] = ($variation_quantities[$variation_id] ?? 0) + $item['quantity'];
+            $total_in_category += $item['quantity'];
+        }
+
+        foreach ($variation_quantities as $variation_id => $qty) {
+            if ($qty < $min_qty) {
+                $name    = wc_get_product($variation_id)->get_name();
+                $errors[] = str_replace(['{min}', '{name}', '{current}'], [$min_qty, $name, $qty], $msg_var);
+            }
+        }
+
+        if ($total_in_category < $min_total) {
+            $errors[] = str_replace(['{min}', '{current}'], [$min_total, $total_in_category], $msg_total);
+        }
+
+        if (defined('DOING_AJAX') && DOING_AJAX) {
+            wp_send_json([
+                'valid'    => empty($errors),
+                'messages' => $errors,
+            ]);
+        } else {
+            foreach ($errors as $msg) {
+                wc_add_notice($msg, 'error');
+            }
         }
     }
 
-    if (($current_qty + $quantity) < $min_qty) {
-        wc_add_notice("Минимальное количество для этой вариации — {$min_qty} шт.", 'error');
-        return false;
-    }
-
-    return $passed;
-}, 10, 5);
-
-// === Проверка при оформлении ===
-add_action('woocommerce_checkout_process', 'seedling_validate_cart');
-add_action('wp_ajax_seedling_validate_cart_full', 'seedling_validate_cart');
-add_action('wp_ajax_nopriv_seedling_validate_cart_full', 'seedling_validate_cart');
-
-function seedling_validate_cart() {
-    $slug = get_option('woo_seedling_category_slug', 'seedling');
-    $min_qty = (int)get_option('woo_seedling_min_variation', 5);
-    $min_total = (int)get_option('woo_seedling_min_total', 20);
-    $msg_var = get_option('woo_seedling_msg_variation');
-    $msg_total = get_option('woo_seedling_msg_total');
-
-    $variation_quantities = [];
-    $total_in_category = 0;
-    $errors = [];
-
-    foreach (WC()->cart->get_cart() as $item) {
-        $variation_id = $item['variation_id'];
-        $parent_id = $item['product_id'];
-        if (!$variation_id || !has_term($slug, 'product_cat', $parent_id)) continue;
-
-        $variation_quantities[$variation_id] = ($variation_quantities[$variation_id] ?? 0) + $item['quantity'];
-        $total_in_category += $item['quantity'];
-    }
-
-    foreach ($variation_quantities as $variation_id => $qty) {
-        if ($qty < $min_qty) {
-            $name = wc_get_product($variation_id)->get_name();
-            $errors[] = str_replace(['{min}', '{name}', '{current}'], [$min_qty, $name, $qty], $msg_var);
+    /**
+     * Returns quantity of a variation currently in the cart.
+     */
+    public function get_cart_qty(): void
+    {
+        if (!isset($_GET['variation_id'])) {
+            wp_send_json_error(['message' => 'Missing variation_id']);
         }
+
+        $variation_id = (int) $_GET['variation_id'];
+        $sum          = 0;
+
+        foreach (WC()->cart->get_cart() as $item) {
+            if ((int) $item['variation_id'] === $variation_id) {
+                $sum += (int) $item['quantity'];
+            }
+        }
+
+        wp_send_json_success(['quantity' => $sum]);
     }
 
-    if ($total_in_category < $min_total) {
-        $errors[] = str_replace(['{min}', '{current}'], [$min_total, $total_in_category], $msg_total);
-    }
+    /**
+     * Provides total quantity of products from the configured category.
+     */
+    public function get_cat_total(): void
+    {
+        $slug      = get_option('woo_seedling_category_slug', 'seedling');
+        $min_total = (int) get_option('woo_seedling_min_total', 20);
 
-    if (defined('DOING_AJAX') && DOING_AJAX) {
+        $total = 0;
+        foreach (WC()->cart->get_cart() as $item) {
+            if (has_term($slug, 'product_cat', $item['product_id'])) {
+                $total += $item['quantity'];
+            }
+        }
+
         wp_send_json([
-            'valid' => empty($errors),
-            'messages' => $errors,
+            'total' => $total,
+            'min'   => $min_total,
+            'valid' => $total >= $min_total,
         ]);
-    } else {
-        foreach ($errors as $msg) {
-            wc_add_notice($msg, 'error');
+    }
+
+    /**
+     * Enqueues script that limits quantity selection on product page.
+     */
+    public function enqueue_product_script(): void
+    {
+        if (!is_product()) {
+            return;
         }
+
+        wp_enqueue_script(
+            'seedling-product-limit',
+            plugin_dir_url(__FILE__) . 'assets/js/seedling-product-limit.js',
+            ['jquery'],
+            null,
+            true
+        );
+
+        wp_localize_script(
+            'seedling-product-limit',
+            'seedlingProductSettings',
+            [
+                'minQty' => (int) get_option('woo_seedling_min_variation', 5),
+                'slug'   => get_option('woo_seedling_category_slug', 'seedling'),
+            ]
+        );
+    }
+
+    /**
+     * Enqueues cart validation script on cart and checkout pages.
+     */
+    public function enqueue_cart_script(): void
+    {
+        if (!is_cart() && !is_checkout()) {
+            return;
+        }
+
+        wp_enqueue_script(
+            'seedling-cart-validation',
+            plugin_dir_url(__FILE__) . 'assets/js/seedling-cart-validation.js',
+            ['jquery'],
+            null,
+            true
+        );
+
+        wp_localize_script(
+            'seedling-cart-validation',
+            'seedlingCartSettings',
+            [
+                'ajaxUrl'       => admin_url('admin-ajax.php?action=seedling_validate_cart_full'),
+                'totalCheckUrl' => admin_url('admin-ajax.php?action=seedling_get_cat_total'),
+            ]
+        );
     }
 }
 
-/**
- * Handle AJAX request to get quantity of a variation already in the cart.
- *
- * Summarizes the quantity of products with a given variation ID and returns
- * the amount in a JSON response. This allows the frontend to adjust the
- * quantity input according to the current cart state.
- */
-function seedling_get_cart_qty() {
-    if (!isset($_GET['variation_id'])) {
-        wp_send_json_error(['message' => 'Missing variation_id']);
-    }
-
-    $variation_id = (int)$_GET['variation_id'];
-    $sum = 0;
-
-    foreach (WC()->cart->get_cart() as $item) {
-        if ((int)$item['variation_id'] === $variation_id) {
-            $sum += (int)$item['quantity'];
-        }
-    }
-
-    wp_send_json_success(['quantity' => $sum]);
-}
-
-add_action('wp_ajax_seedling_get_cart_qty', 'seedling_get_cart_qty');
-add_action('wp_ajax_nopriv_seedling_get_cart_qty', 'seedling_get_cart_qty');
-
-/**
- * Возвращает общее количество товаров из категории в корзине.
- *
- * Используется для проверки минимального общего количества на стороне клиента.
- */
-function seedling_get_cat_total() {
-    $slug      = get_option('woo_seedling_category_slug', 'seedling');
-    $min_total = (int) get_option('woo_seedling_min_total', 20);
-
-    $total = 0;
-    foreach (WC()->cart->get_cart() as $item) {
-        if (has_term($slug, 'product_cat', $item['product_id'])) {
-            $total += $item['quantity'];
-        }
-    }
-
-    wp_send_json([
-        'total' => $total,
-        'min'   => $min_total,
-        'valid' => $total >= $min_total,
-    ]);
-}
-
-add_action('wp_ajax_seedling_get_cat_total', 'seedling_get_cat_total');
-add_action('wp_ajax_nopriv_seedling_get_cat_total', 'seedling_get_cat_total');
-
-// === Подключение скриптов ===
-
-/**
- * Подключает скрипт ограничения количества на странице товара.
- */
-add_action('wp_enqueue_scripts', function () {
-    if (!is_product()) {
-        return;
-    }
-
-    wp_enqueue_script(
-        'seedling-product-limit',
-        plugin_dir_url(__FILE__) . 'assets/js/seedling-product-limit.js',
-        ['jquery'], // Подключаем jQuery, используемую WordPress
-        null,
-        true
-    );
-
-    // Передаём минимальное количество и слаг категории в скрипт
-    wp_localize_script(
-        'seedling-product-limit',
-        'seedlingProductSettings',
-        [
-            'minQty' => (int) get_option('woo_seedling_min_variation', 5),
-            'slug'    => get_option('woo_seedling_category_slug', 'seedling'),
-        ]
-    );
-});
-
-/**
- * Подключает валидацию корзины на страницах корзины и оформления заказа.
- */
-add_action('wp_enqueue_scripts', function () {
-    if (!is_cart() && !is_checkout()) {
-        return;
-    }
-
-    wp_enqueue_script(
-        'seedling-cart-validation',
-        plugin_dir_url(__FILE__) . 'assets/js/seedling-cart-validation.js',
-        ['jquery'],
-        null,
-        true
-    );
-
-    // Передаём AJAX‑адреса в скрипт для проверки корзины
-    wp_localize_script(
-        'seedling-cart-validation',
-        'seedlingCartSettings',
-        [
-            'ajaxUrl'       => admin_url('admin-ajax.php?action=seedling_validate_cart_full'),
-            'totalCheckUrl' => admin_url('admin-ajax.php?action=seedling_get_cat_total'),
-        ]
-    );
-});
+new Seedling_Limiter();


### PR DESCRIPTION
## Summary
- encapsulate plugin hooks into `Seedling_Limiter` class
- add PHPDoc blocks to describe public methods
- document JS scripts and variables

## Testing
- `php -l woo-seedling-limiter.php`

------
https://chatgpt.com/codex/tasks/task_e_6871811738c0832d8adfb1e6f4c45d6c