### PR TITLE
Remove redundant AJAX call for cart validation

### DIFF
--- a/assets/js/seedling-cart-validation.js
+++ b/assets/js/seedling-cart-validation.js
@@ -1,9 +1,8 @@
 // Скрипт проверяет корзину на соответствие минимальным ограничениям.
 document.addEventListener('DOMContentLoaded', function () {
-    // URL-адрес для проверки корзины через AJAX
+    // URL-адрес для проверки корзины через AJAX.
+    // Сервер возвращает список сообщений и признак валидности.
     const ajaxUrl = seedlingCartSettings.ajaxUrl;
-    // URL-адрес для получения общего количества по категории
-    const totalUrl = seedlingCartSettings.totalCheckUrl;
     // Кнопки оформления заказа, которые нужно блокировать при ошибках
     const selectors = ['.checkout-button', '#place_order', 'a.checkout'];
     // ID контейнера для вывода сообщений об ошибках
@@ -72,26 +71,16 @@ document.addEventListener('DOMContentLoaded', function () {
         fetch(ajaxUrl, { credentials: 'same-origin' })
             .then(r => r.json())
             .then(d => {
-                let valid = d.valid;
-                let messages = d.messages || [];
+                const valid = d.valid;
+                const messages = d.messages || [];
 
-                fetch(totalUrl, { credentials: 'same-origin' })
-                    .then(r2 => r2.json())
-                    .then(catData => {
-                        if (!catData.valid) {
-                            valid = false;
-                            const msg = `Общее количество товаров из категории должно быть не менее ${catData.min}. Сейчас — ${catData.total}.`;
-                            messages.push(msg);
-                        }
-
-                        if (valid) {
-                            document.getElementById(noticeId)?.remove();
-                            disableBtns(false);
-                        } else {
-                            showMessages(messages);
-                            disableBtns(true);
-                        }
-                    });
+                if (valid) {
+                    document.getElementById(noticeId)?.remove();
+                    disableBtns(false);
+                } else {
+                    showMessages(messages);
+                    disableBtns(true);
+                }
             });
     }
 

--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -331,8 +331,7 @@ class Seedling_Limiter
             'seedling-cart-validation',
             'seedlingCartSettings',
             [
-                'ajaxUrl'       => admin_url('admin-ajax.php?action=seedling_validate_cart_full'),
-                'totalCheckUrl' => admin_url('admin-ajax.php?action=seedling_get_cat_total'),
+                'ajaxUrl' => admin_url('admin-ajax.php?action=seedling_validate_cart_full'),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- rely only on main AJAX endpoint for cart validation
- remove total check URL from plugin script localization

## Testing
- `php -l woo-seedling-limiter.php`
- `node --check assets/js/seedling-cart-validation.js`


------
https://chatgpt.com/codex/tasks/task_e_6871866a3ca0832dafde5d80f12572ea