### PR TITLE
Add nonce checks to AJAX requests

### DIFF
--- a/assets/js/seedling-cart-validation.js
+++ b/assets/js/seedling-cart-validation.js
@@ -68,7 +68,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Проверяет корзину через AJAX и отображает найденные ошибки
     function checkCart() {
-        fetch(ajaxUrl, { credentials: 'same-origin' })
+        fetch(ajaxUrl + `&nonce=${seedlingCartSettings.nonce}`, { credentials: 'same-origin' })
             .then(r => r.json())
             .then(d => {
                 const valid = d.valid;

--- a/assets/js/seedling-product-limit.js
+++ b/assets/js/seedling-product-limit.js
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const variationId = parseInt(variationIdInput.value || '0');
         if (!variationId) return;
 
-        fetch(`/wp-admin/admin-ajax.php?action=seedling_get_cart_qty&variation_id=${variationId}`, { credentials: 'same-origin' })
+        fetch(`/wp-admin/admin-ajax.php?action=seedling_get_cart_qty&variation_id=${variationId}&nonce=${seedlingProductSettings.nonce}`, { credentials: 'same-origin' })
             .then(r => r.json())
             .then(data => {
                 if (!data.success) return;


### PR DESCRIPTION
## Summary
- create a nonce constant for AJAX actions
- validate nonce in AJAX handlers
- pass nonces to JS via `wp_localize_script`
- send nonce with `fetch` requests

## Testing
- `php -l woo-seedling-limiter.php`

------
https://chatgpt.com/codex/tasks/task_e_6871880b8198832dba3e2fd83fc60c49