### PR TITLE
Ensure minus button disabled at minimum qty

### DIFF
--- a/assets/js/seedling-product-limit.js
+++ b/assets/js/seedling-product-limit.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (parseInt(qtyInput.value || '0') < enforcedMin) {
             qtyInput.value = enforcedMin;
         }
+        updateMinusButtonState();
     }
 
     /**
@@ -49,7 +50,26 @@ document.addEventListener('DOMContentLoaded', function () {
             if (parseInt(qtyInput.value || '0') < enforcedMin) {
                 qtyInput.value = enforcedMin;
             }
+            updateMinusButtonState();
         }, 100);
+    }
+
+    /**
+     * Activates or disables the minus button based on current quantity.
+     * Prevents decreasing below the enforced minimum value.
+     */
+    function updateMinusButtonState() {
+        if (!boundMinusBtn) return;
+        const qty = parseInt(qtyInput.value || '0');
+        if (qty <= enforcedMin) {
+            boundMinusBtn.disabled = true;
+            boundMinusBtn.classList.add('disabled');
+            boundMinusBtn.setAttribute('aria-disabled', 'true');
+        } else {
+            boundMinusBtn.disabled = false;
+            boundMinusBtn.classList.remove('disabled');
+            boundMinusBtn.removeAttribute('aria-disabled');
+        }
     }
 
     /**
@@ -82,6 +102,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     minusBtn.addEventListener('click', handleMinusClick);
                     boundMinusBtn = minusBtn;
                 }
+                updateMinusButtonState();
             });
     }
 
@@ -100,6 +121,10 @@ document.addEventListener('DOMContentLoaded', function () {
         variationIdInput.value = variationId;
         checkAndUpdateQuantity();
     });
+
+    // Выполним проверку сразу при загрузке страницы на случай,
+    // если вариация уже выбрана по умолчанию
+    checkAndUpdateQuantity();
 	
     // Отслеживаем процесс добавления товара в корзину, чтобы при ошибке
     // показать сообщение из сессии WooCommerce.

--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WooCommerce Seedling Quantity Limiter
  * Description: Ограничения на количество товаров из категории: минимум на вариацию и общий минимум по категории.
- * Version: 1.3
+ * Version: 1.4
  * Author: Дмитрий Анисимов
  */
 


### PR DESCRIPTION
## Summary
- disable the minus button when the enforced minimum is reached
- run quantity check on initial page load
- bump plugin version to 1.4

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6872dea24e10832d9d133323ca232788