### PR TITLE
Prioritize theme container for cart validation messages

### DIFF
--- a/assets/js/seedling-cart-validation.js
+++ b/assets/js/seedling-cart-validation.js
@@ -16,13 +16,16 @@ document.addEventListener('DOMContentLoaded', function () {
 			box.id = noticeId;
 			box.className = 'woocommerce-error';
 
-			const insertPlaces = [
-				document.querySelector('.woocommerce-notices-wrapper'),        // основное место
-				document.querySelector('.woocommerce-cart-form'),              // корзина
-				document.querySelector('.woocommerce-checkout-review-order'),  // оформление
-				document.querySelector('.woocommerce-mini-cart'),              // модальная
-				document.querySelector('body')                                 // fallback
-			];
+                        // Список контейнеров, куда можно поместить сообщения.
+                        // Используется первый найденный элемент.
+                        const insertPlaces = [
+                                document.querySelector(".mfn-ch-content"),                    // контент темы
+                                document.querySelector(".woocommerce-notices-wrapper"),        // основное место
+                                document.querySelector(".woocommerce-cart-form"),              // корзина
+                                document.querySelector(".woocommerce-checkout-review-order"),  // оформление заказа
+                                document.querySelector(".woocommerce-mini-cart"),              // модальная корзина
+                                document.querySelector("body")               // запасной вариант
+                        ];
 
 			for (const el of insertPlaces) {
 				if (el) {


### PR DESCRIPTION
## Summary
- extend locations for dynamic cart error box
- ensure messages show inside `.mfn-ch-content` when available

## Testing
- `php -l woo-seedling-limiter.php`

------
https://chatgpt.com/codex/tasks/task_e_687377189824832da311f0b6479fb4b1