### PR TITLE
Fix minimum quantity enforcement

### DIFF
--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -460,9 +460,10 @@ class Seedling_Limiter
             'seedling-product-limit',
             'seedlingProductSettings',
             [
-                'minQty' => (int) get_option('woo_seedling_min_variation', 5),
-                'slug'   => get_option('woo_seedling_category_slug', 'seedling'),
-                'nonce'  => wp_create_nonce(self::NONCE_ACTION),
+                'minQty'  => (int) get_option('woo_seedling_min_variation', 5),
+                'slug'    => get_option('woo_seedling_category_slug', 'seedling'),
+                'nonce'   => wp_create_nonce(self::NONCE_ACTION),
+                'ajaxUrl' => admin_url('admin-ajax.php'),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- ensure quantity input exists before updating
- fetch cart quantity via provided admin-ajax URL
- support themes that dynamically create the quantity field
- pass AJAX URL to product JS

## Testing
- `php -l woo-seedling-limiter.php`
- `node --check assets/js/seedling-product-limit.js`


------
https://chatgpt.com/codex/tasks/task_e_68750d0c905c832da735599f861a0212