### PR TITLE
Improve mini cart detection

### DIFF
--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -550,13 +550,29 @@ class Seedling_Limiter
      * Checks whether the mini cart should be considered active.
      *
      * SRP: определяет наличие мини-корзины на сайте.
-     * Позволяет расширять логику через фильтр 'seedling_limiter_has_mini_cart'.
+     * Метод проверяет стандартный виджет WooCommerce и DOM‑хуки популярных тем
+     * (например, `mfn-ch-footer-buttons`). Позволяет расширять логику через
+     * фильтр 'seedling_limiter_has_mini_cart'.
      */
     private function has_mini_cart(): bool
     {
+        // Проверяем стандартный виджет WooCommerce.
         $active_widget = is_active_widget(false, false, 'woocommerce_widget_cart', true);
 
-        return (bool) apply_filters('seedling_limiter_has_mini_cart', $active_widget);
+        // DOM-хуки популярных тем для вывода мини‑корзины.
+        $theme_hooks = ['mfn-ch-footer-buttons'];
+        $hook_found  = false;
+
+        foreach ($theme_hooks as $hook) {
+            if (has_action($hook)) {
+                $hook_found = true;
+                break;
+            }
+        }
+
+        $detected = $active_widget || $hook_found;
+
+        return (bool) apply_filters('seedling_limiter_has_mini_cart', $detected);
     }
 
     /**


### PR DESCRIPTION
## Summary
- enhance `has_mini_cart()` by checking theme hooks like `mfn-ch-footer-buttons`
- keep filter for theme customisation

## Testing
- `php -l woo-seedling-limiter.php`

------
https://chatgpt.com/codex/tasks/task_e_68752c44f0f0832da5ee6fc4f02fe3c0