### PR TITLE
Improve mini cart detection

### DIFF
--- a/assets/js/seedling-cart-limit.js
+++ b/assets/js/seedling-cart-limit.js
@@ -1,0 +1,53 @@
+// Скрипт ограничивает уменьшение количества в обычной корзине.
+// Аналогичен mini-cart-limit.js, но работает на странице корзины.
+document.addEventListener('DOMContentLoaded', function () {
+    const min = seedlingCartLimitSettings.minQty;
+
+    /**
+     * Обновляет состояние конкретной строки корзины.
+     * SRP: устанавливает минимальное значение и блокирует кнопку минус.
+     *
+     * @param {Element} item Элемент с классом seedling-category-item
+     */
+    function processItem(item) {
+        const qtyInput = item.querySelector('input.qty');
+        const minusBtn = item.querySelector('.quantity .minus');
+
+        function enforce() {
+            if (qtyInput) {
+                let val = parseInt(qtyInput.value || '0');
+                if (val < min) {
+                    val = min;
+                    qtyInput.value = val;
+                    qtyInput.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+                if (minusBtn) {
+                    if (val <= min) {
+                        minusBtn.disabled = true;
+                        minusBtn.classList.add('disabled');
+                        minusBtn.setAttribute('aria-disabled', 'true');
+                    } else {
+                        minusBtn.disabled = false;
+                        minusBtn.classList.remove('disabled');
+                        minusBtn.removeAttribute('aria-disabled');
+                    }
+                }
+            }
+        }
+
+        qtyInput?.addEventListener('input', enforce);
+        minusBtn?.addEventListener('click', () => setTimeout(enforce, 50));
+        enforce();
+    }
+
+    /**
+     * Инициализирует обработку всех элементов корзины.
+     */
+    function init() {
+        document.querySelectorAll('.cart_item.seedling-category-item').forEach(processItem);
+    }
+
+    init();
+    // Повторная инициализация после обновления корзины WooCommerce
+    jQuery(document.body).on('updated_wc_div', init);
+});

--- a/assets/js/seedling-mini-cart-limit.js
+++ b/assets/js/seedling-mini-cart-limit.js
@@ -1,0 +1,53 @@
+// Скрипт ограничивает уменьшение количества в мини-корзине.
+// Управляет полем количества и кнопкой "минус" для товаров из целевой категории.
+document.addEventListener('DOMContentLoaded', function () {
+    const min = seedlingMiniCartSettings.minQty;
+
+    /**
+     * Обновляет состояние конкретного элемента мини-корзины.
+     * SRP: устанавливает минимальное значение и блокирует кнопку минус.
+     *
+     * @param {Element} item Элемент с классом seedling-category-item
+     */
+    function processItem(item) {
+        const qtyInput = item.querySelector('input.qty');
+        const minusBtn = item.querySelector('.quantity .minus');
+
+        function enforce() {
+            if (qtyInput) {
+                let val = parseInt(qtyInput.value || '0');
+                if (val < min) {
+                    val = min;
+                    qtyInput.value = val;
+                    qtyInput.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+                if (minusBtn) {
+                    if (val <= min) {
+                        minusBtn.disabled = true;
+                        minusBtn.classList.add('disabled');
+                        minusBtn.setAttribute('aria-disabled', 'true');
+                    } else {
+                        minusBtn.disabled = false;
+                        minusBtn.classList.remove('disabled');
+                        minusBtn.removeAttribute('aria-disabled');
+                    }
+                }
+            }
+        }
+
+        qtyInput?.addEventListener('input', enforce);
+        minusBtn?.addEventListener('click', () => setTimeout(enforce, 50));
+        enforce();
+    }
+
+    /**
+     * Инициализирует обработку всех актуальных элементов мини-корзины.
+     */
+    function init() {
+        document.querySelectorAll('.seedling-category-item').forEach(processItem);
+    }
+
+    init();
+    // Повторная инициализация после обновления мини-корзины WooCommerce
+    jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', init);
+});


### PR DESCRIPTION
## Summary
- enhance `has_mini_cart()` by checking theme hooks like `mfn-ch-footer-buttons`
- keep filter for theme customisation
- restrict quantity editing within the mini cart
- block decreasing quantity below minimum on the main cart page as well

## Testing
- `php -l woo-seedling-limiter.php`
- `node -c assets/js/seedling-cart-validation.js`
- `node -c assets/js/seedling-mini-cart-limit.js`
- `node -c assets/js/seedling-cart-limit.js`


------
https://chatgpt.com/codex/tasks/task_e_68752c44f0f0832da5ee6fc4f02fe3c0