### PR TITLE
Skip cart checks when no category items present

### DIFF
--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -398,6 +398,16 @@ class Seedling_Limiter
             $total_in_category += $item['quantity'];
         }
 
+        // Прерываемся, если подходящих товаров в корзине нет
+        if ($total_in_category === 0) {
+            if (defined('DOING_AJAX') && DOING_AJAX) {
+                // Для AJAX-сценария сразу возвращаем успешный ответ
+                wp_send_json(['valid' => true, 'messages' => []]);
+            }
+
+            return;
+        }
+
         // Формируем сообщения об ошибках для вариаций
         foreach ($variation_quantities as $variation_id => $qty) {
             if ($qty < $min_qty) {


### PR DESCRIPTION
## Summary
- avoid generating errors when the cart doesn't contain category items
- early return in `Seedling_Limiter::validate_cart`

## Testing
- `php -l woo-seedling-limiter.php`
- `php /tmp/test_validate_cart.php`

------
https://chatgpt.com/codex/tasks/task_e_68753a39ce10832d857f77bd6cd22911