### PR TITLE
Add catch handler for cart validation fetch

### DIFF
--- a/assets/js/seedling-cart-validation.js
+++ b/assets/js/seedling-cart-validation.js
@@ -110,6 +110,11 @@ document.addEventListener('DOMContentLoaded', function () {
                     showMessages(messages);
                     disableBtns(true);
                 }
+            })
+            .catch(() => {
+                // При сбое запроса сообщаем пользователю и блокируем оформление
+                showMessages(['Ошибка проверки корзины']);
+                disableBtns(true);
             });
     }
 


### PR DESCRIPTION
## Summary
- handle fetch errors in `checkCart` of seedling-cart-validation.js

## Testing
- `node --check assets/js/seedling-cart-validation.js && php -l woo-seedling-limiter.php`

------
https://chatgpt.com/codex/tasks/task_e_687544aeea68832d98fcc71fc57f20e7