### PR TITLE
Add user notification on AJAX failure

### DIFF
--- a/assets/js/seedling-product-limit.js
+++ b/assets/js/seedling-product-limit.js
@@ -42,6 +42,28 @@ document.addEventListener('DOMContentLoaded', function () {
     let boundMinusBtn = null;
 
     /**
+     * Показывает сообщение об ошибке в стиле WooCommerce.
+     *
+     * SRP: отвечает только за вывод уведомления пользователю.
+     *
+     * @param {string} msg Текст ошибки для отображения.
+     */
+    function showError(msg) {
+        let wrapper = document.querySelector('.woocommerce-notices-wrapper');
+        if (!wrapper) {
+            wrapper = document.createElement('div');
+            wrapper.className = 'woocommerce-notices-wrapper';
+            const form = document.querySelector('form.cart');
+            if (form) {
+                form.prepend(wrapper);
+            } else {
+                document.body.prepend(wrapper);
+            }
+        }
+        wrapper.innerHTML = `<ul class="woocommerce-error"><li>${msg}</li></ul>`;
+    }
+
+    /**
      * Binds event listeners to the quantity input and minus button.
      *
      * SRP: отвечает только за присоединение обработчиков для поля
@@ -161,16 +183,16 @@ document.addEventListener('DOMContentLoaded', function () {
                 updateMinusButtonState();
             })
             .catch(() => {
-                // Если запрос не удался, выводим сообщение и блокируем кнопку
-                // добавления в корзину, чтобы избежать некорректного количества
-                // в заказе.
+                // Если запрос не удался, сообщаем пользователю
+                // и блокируем кнопку добавления в корзину,
+                // чтобы избежать некорректного количества в заказе.
                 const btn = document.querySelector('.single_add_to_cart_button');
                 if (btn) {
                     btn.disabled = true;
                     btn.classList.add('disabled');
                     btn.setAttribute('aria-disabled', 'true');
                 }
-                console.error('Не удалось получить минимальное количество');
+                showError('Не удалось проверить минимальное количество');
             });
     }
 


### PR DESCRIPTION
## Summary
- display WooCommerce style error notice when product page AJAX call fails
- update logic so both cart and product page inform user of errors

## Testing
- `node --check assets/js/seedling-product-limit.js`
- `node --check assets/js/seedling-cart-validation.js`
- `php -l woo-seedling-limiter.php`

------
https://chatgpt.com/codex/tasks/task_e_68754b3e292c832d9f3a1015157849da