### PR TITLE
Fix cart item class filter signature

### DIFF
--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -697,12 +697,19 @@ class Seedling_Limiter
      * Отмечает элементы корзины специальным классом при совпадении категории.
      *
      * SRP: только добавляет CSS‑класс без изменения других данных.
+     *
+     * @param string $classes      Строка с CSS‑классами элемента.
+     * @param array  $cart_item    Данные товара из корзины.
+     * @param string $cart_item_key Ключ текущего товара в корзине.
+     *
+     * @return string Обновлённая строка классов элемента корзины.
      */
-    public function mark_cart_item(array $classes, array $cart_item, string $cart_item_key): array
+    public function mark_cart_item(string $classes, array $cart_item, string $cart_item_key): string
     {
         $slug = get_option('woo_seedling_category_slug', 'seedling');
+
         if (has_term($slug, 'product_cat', $cart_item['product_id'])) {
-            $classes[] = 'seedling-category-item';
+            $classes = "$classes seedling-category-item";
         }
 
         return $classes;


### PR DESCRIPTION
## Summary
- update `mark_cart_item()` to accept and return a string
- append cart item CSS class with a leading space
- document new parameter and return types

## Testing
- `php -l woo-seedling-limiter.php`

------
https://chatgpt.com/codex/tasks/task_e_6875700f0468832d9fba34ca61635524