### PR TITLE
Add variations parameter to cart validation

### DIFF
--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -321,13 +321,16 @@ class Seedling_Limiter
      * @param int      $product_id   ID of the product being added.
      * @param int      $quantity     Quantity requested by the customer.
      * @param int|null $variation_id ID of the variation being added.
+     * @param array    $variations   Массив атрибутов выбранной вариации.
      *
      * @return bool Whether the add to cart action is allowed.
      */
-    public function validate_add_to_cart($passed, $product_id, $quantity, $variation_id = null)
+    public function validate_add_to_cart($passed, $product_id, $quantity, $variation_id = null, $variations = [])
     {
         $slug    = get_option('woo_seedling_category_slug', 'seedling');
         $min_qty = (int) get_option('woo_seedling_min_variation', 5);
+        // Пятый аргумент $variations присутствует для совместимости с фильтром,
+        // но логика метода не зависит от его содержимого.
         if (!$variation_id) {
             return $passed;
         }


### PR DESCRIPTION
## Summary
- update `validate_add_to_cart()` signature to include the `$variations` parameter
- document the new parameter in phpdoc
- note unused argument in code comments

## Testing
- `php -l woo-seedling-limiter.php`


------
https://chatgpt.com/codex/tasks/task_e_687571146ed8832db96baaf0cb1b5e99