### PR TITLE
Fix stale error notices

### DIFF
--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -745,7 +745,11 @@ class Seedling_Limiter
                 $this->get_variation_template()
             );
 
-            wc_add_notice($message, 'error');
+            // Add a notice only during regular (non-AJAX) requests to prevent
+            // outdated messages from appearing later, e.g. on the checkout page.
+            if (!wp_doing_ajax()) {
+                wc_add_notice($message, 'error');
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- clear stale notices when enforcing minimum quantity during AJAX updates

## Testing
- `php -l woo-seedling-limiter.php`

------
https://chatgpt.com/codex/tasks/task_e_687573157f38832daaee4b19d4f7401f