### PR TITLE
Add global quantity step option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ WooCommerce Seedling Quantity Limiter enforces minimum order quantities for prod
 - Display customizable warning messages on product, cart and checkout pages.
 - JavaScript integrations to enforce limits on product pages, the cart and mini cart.
 - Admin settings page under **WooCommerce → Ограничения товаров**.
+- Configure a global quantity step that applies by default to all rules.
 
 ## Installation
 1. Upload the plugin folder to `wp-content/plugins`.
@@ -22,6 +23,7 @@ WooCommerce Seedling Quantity Limiter enforces minimum order quantities for prod
   - `msg_variation` – message shown when a variation is below the minimum.
   - `msg_total` – message shown when the category total is too low.
   - `step` – quantity step increment.
+  - **Шаг по умолчанию** (`woo_seedling_step`) – default increment for new rules.
 
 ## Development Notes
 Source scripts live in `assets/js`. Minified files with the `.min.js` suffix are included for production. When changing a script, regenerate its minified counterpart using any preferred tool, for example:


### PR DESCRIPTION
## Summary
- add new `woo_seedling_step` option for default quantity step
- expose this option on the settings page
- load the option into plugin properties and use it as default
- ensure step value is stored/removed on activation/uninstall
- document the new setting

## Testing
- `php -l woo-seedling-limiter.php`

------
https://chatgpt.com/codex/tasks/task_e_687be294b770832db3d5c7bc99a79950