### PR TITLE
Исправлено неверное отображение количества в корзине

### DIFF
--- a/woo-seedling-limiter.php
+++ b/woo-seedling-limiter.php
@@ -683,8 +683,12 @@ class Seedling_Limiter
         $minimum      = max($min - $current, 1);
 
         if ($minimum > 1) {
-            $args['min_value']   = $minimum;
-            $args['input_value'] = $minimum;
+            $args['min_value'] = $minimum;
+            // Если текущее значение меньше минимума, отображаем минимально
+            // допустимое количество, иначе сохраняем фактическое значение.
+            if (($args['input_value'] ?? 0) < $minimum) {
+                $args['input_value'] = $minimum;
+            }
         }
 
         // Передаём шаг изменения количества для фронтенда.


### PR DESCRIPTION
## Summary
- предотвращено принудительное отображение минимального количества товаров в корзине и мини-корзине

## Testing
- `php -l woo-seedling-limiter.php`


------
https://chatgpt.com/codex/tasks/task_e_68b002031d48832d8c194725e35e2883